### PR TITLE
Feat/add var for install location

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The following variables are available for this role:
 | Variable                | Required | Default   | Choices | Comments                                       |
 |-------------------------|----------|-----------|---------|------------------------------------------------|
 | quarto_versions         | no       | ["1.6.43"] |         | List of Quarto versions to install             |
+| quarto_install_root_dir | no       | /opt/quarto |        | Root directory where Quarto will be installed  |
 
 ## Example Playbook
 
@@ -19,6 +20,19 @@ The following variables are available for this role:
 - hosts: all
   roles:
     - appsilon.quarto
+```
+
+Or with custom variables:
+
+```yaml
+- hosts: all
+  roles:
+    - role: appsilon.quarto
+      vars:
+        quarto_versions:
+          - "1.6.43"
+          - "1.5.29"
+        quarto_install_root_dir: /usr/local/quarto
 ```
 
 ## Development

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 ---
 quarto_versions:
 - "1.6.43"
+quarto_install_root_dir: /opt/quarto

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -2,6 +2,8 @@
 - name: Verify
   hosts: all
   pre_tasks:
+    - name: include defaults
+      include_vars: "{{ playbook_dir }}/../../defaults/main.yml"
     - name: include vars
       include_vars: "{{ playbook_dir }}/../../tests/vars/main.yml"
   tasks:

--- a/tasks/install-quarto.yml
+++ b/tasks/install-quarto.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create directory structure for Quarto
   ansible.builtin.file:
-    path: "/opt/quarto/lib/{{ quarto_version }}"
+    path: "{{ quarto_install_root_dir }}/{{ quarto_version }}"
     state: directory
     mode: '0755'
 
@@ -14,6 +14,6 @@
 - name: Extract Quarto tar.gz
   ansible.builtin.unarchive:
     src: "/tmp/quarto-{{ quarto_version }}-linux-amd64.tar.gz"
-    dest: "/opt/quarto/lib/{{ quarto_version }}"
+    dest: "{{ quarto_install_root_dir }}/{{ quarto_version }}"
     remote_src: true
     extra_opts: [--strip-components=1]

--- a/tests/tasks/post.yml
+++ b/tests/tasks/post.yml
@@ -2,5 +2,5 @@
 ---
 - name: Verify  # noqa: no-changed-when
   ansible.builtin.command:
-    cmd: "/opt/quarto/lib/{{ item }}/bin/quarto check"
+    cmd: "{{ quarto_install_root_dir }}/{{ item }}/bin/quarto check"
   loop: "{{ quarto_versions }}"


### PR DESCRIPTION
## Description
Directory where quarto is installed can be set now via `quarto_install_root_dir` variable

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
