### PR TITLE
feat: add support for default Quarto version symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following variables are available for this role:
 |-------------------------|----------|-----------|---------|------------------------------------------------|
 | quarto_versions         | no       | ["1.6.43"] |         | List of Quarto versions to install             |
 | quarto_install_root_dir | no       | /opt/quarto |        | Root directory where Quarto will be installed  |
+| quarto_default_version  | no       | First version in quarto_versions list | | When set, creates a symlink at /usr/local/bin/quarto pointing to this version |
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,3 +3,4 @@
 quarto_versions:
 - "1.6.43"
 quarto_install_root_dir: /opt/quarto
+quarto_default_version: "{{ quarto_versions | first }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,3 +14,10 @@
   loop: "{{ quarto_versions }}"
   loop_control:
     loop_var: quarto_version
+
+- name: Create symlink for default Quarto version
+  ansible.builtin.file:
+    src: "{{ quarto_install_root_dir }}/{{ quarto_default_version }}/bin/quarto"
+    dest: "/usr/local/bin/quarto"
+    state: link
+  when: quarto_default_version | default('') | length > 0

--- a/tests/tasks/post.yml
+++ b/tests/tasks/post.yml
@@ -4,3 +4,18 @@
   ansible.builtin.command:
     cmd: "{{ quarto_install_root_dir }}/{{ item }}/bin/quarto check"
   loop: "{{ quarto_versions }}"
+
+- name: Check if default Quarto symlink exists
+  ansible.builtin.stat:
+    path: /usr/local/bin/quarto
+  register: quarto_symlink
+
+- name: Verify symlink points to default version
+  ansible.builtin.assert:
+    that:
+      - quarto_symlink.stat.islnk is defined
+      - quarto_symlink.stat.islnk
+      - quarto_symlink.stat.lnk_source is defined
+      - quarto_symlink.stat.lnk_source == quarto_install_root_dir + '/' + quarto_default_version + '/bin/quarto'
+    fail_msg: "Default Quarto symlink is not properly configured"
+  when: quarto_default_version | default('') | length > 0


### PR DESCRIPTION
## Description
Having a Quarto binary symlinked to `/usr/local/bin/quarto` may be required by some packages (like [{quarto}](https://cran.r-project.org/web/packages/quarto/index.html)) when run in an R Shiny app.

Added an option to set which version should be used as the default one (symlinked one). By default it's going to be the 1st listed in `quarto_versions`

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
